### PR TITLE
Change to how Resolvers work for project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,9 @@ version := "0.80"
 
 scalaVersion := "2.10.3"
 
-resolvers := Seq("JBoss" at "https://repository.jboss.org/nexus/content/groups/public")
+fullResolvers := {
+  ("JBoss" at "https://repository.jboss.org/nexus/content/groups/public") +: fullResolvers.value
+}
 
 libraryDependencies += "javax.jms" % "jms" % "1.1"
 


### PR DESCRIPTION
There's a problematic behavior (might be bug? might not?) in Ivy that affects SBT retrieving jars. I spoke with a sbt developer and they say this is probably the best way to consistently work around it for now.
